### PR TITLE
Update vetr-collector.sh to not cause error in script output

### DIFF
--- a/vetr-collector.sh
+++ b/vetr-collector.sh
@@ -104,5 +104,5 @@ zip -mj ~/aci-vetr-data.zip /tmp/vetr-collector/*.json
 rm -rf /tmp/vetr-collector
 
 echo Collection complete
-Output writen to ~/aci-vetr-data.zip, i.e. user home folder
+# Output writen to ~/aci-vetr-data.zip, i.e. user home folder
 echo Please provide aci-vetr-data.zip to Cisco for analysis.


### PR DESCRIPTION
Added comment to line 107 of vetr-collector.sh to fix error when running script. Script was still able to execute successfully previously but an error was shown in the CLI output.